### PR TITLE
feat(keyboa): refactor string formatting and type checking

### DIFF
--- a/keyboa/base.py
+++ b/keyboa/base.py
@@ -18,16 +18,17 @@ class Base(BaseCheck):  # pylint: disable = R0902
     Base initial class for Keyboa
     """
 
-    def __init__(  # pylint: disable = R0913
+    def __init__(
         self,
         items: BlockItems,
+        *,
         items_in_row: int = None,
-        front_marker: CallbackDataMarker = str(),
-        back_marker: CallbackDataMarker = str(),
+        front_marker: CallbackDataMarker = "",
+        back_marker: CallbackDataMarker = "",
         copy_text_to_callback: Optional[bool] = True,
         alignment: Union[bool, Iterable] = None,
         alignment_reverse: Optional[bool] = None,
-    ):
+    ) -> None:
         self._items = None
         self.items = items
 

--- a/keyboa/base_check.py
+++ b/keyboa/base_check.py
@@ -66,9 +66,9 @@ class BaseCheck:
         ):
             value_error_message = (
                 "The auto_alignment's item values should be between "
-                "%s and %s. You entered: %s\n"
+                f"{MINIMUM_ITEMS_IN_LINE} and {MAXIMUM_ITEMS_IN_LINE}. "
+                f"You entered: {auto_alignment}\n"
                 "You may define it as 'True' to use AUTO_ALIGNMENT_RANGE."
-                % (MINIMUM_ITEMS_IN_LINE, MAXIMUM_ITEMS_IN_LINE, auto_alignment)
             )
             raise ValueError(value_error_message)
 
@@ -94,6 +94,6 @@ class BaseCheck:
         if keyboard and not isinstance(keyboard, InlineKeyboardMarkup):
             type_error_message = (
                 "Keyboard to which the new items will be added "
-                "should have InlineKeyboardMarkup type. Now it is a %s" % type(keyboard)
+                f"should have InlineKeyboardMarkup type. Now it is a {type(keyboard)}"
             )
             raise TypeError(type_error_message)

--- a/keyboa/button.py
+++ b/keyboa/button.py
@@ -79,6 +79,14 @@ class Button(ButtonCheck):
 
     @property
     def button(self):
+        """Property that generates and returns an InlineKeyboardButton.
+        
+        This is a convenience property that calls the generate() method.
+        It allows accessing the button directly as an attribute.
+        
+        Returns:
+            telebot.types.InlineKeyboardButton: The generated inline keyboard button.
+        """
         return self.generate()
 
     def is_auto_copy_text_to_callback(self):
@@ -118,7 +126,7 @@ class Button(ButtonCheck):
         front_marker = cls.get_checked_marker(front_marker)
         back_marker = cls.get_checked_marker(back_marker)
 
-        callback_data = "%s%s%s" % (front_marker, raw_callback, back_marker)
+        callback_data = f"{front_marker}{raw_callback}{back_marker}"
 
         if not callback_data:
             raise ValueError("The callback data cannot be empty.")
@@ -137,9 +145,9 @@ class Button(ButtonCheck):
             marker = str()
 
         if not isinstance(marker, callback_data_types):
-            type_error_message = "Marker could not have %s type. Only %s allowed." % (
-                type(marker),
-                CallbackDataMarker,
+            type_error_message = (
+                f"Marker could not have {type(marker)} type. "
+                f"Only {CallbackDataMarker} allowed."
             )
             raise TypeError(type_error_message)
 
@@ -153,9 +161,9 @@ class Button(ButtonCheck):
         """
         raw_text = button_data[0]
         if not isinstance(raw_text, button_text_types):
-            type_error_message = "Button text cannot be %s. Only %s allowed." % (
-                type(raw_text),
-                ButtonText,
+            type_error_message = (
+                f"Button text cannot be {type(raw_text)}. "
+                f"Only {ButtonText} allowed."
             )
             raise TypeError(type_error_message)
         text = str(raw_text)

--- a/keyboa/button_check.py
+++ b/keyboa/button_check.py
@@ -21,19 +21,19 @@ class ButtonCheck:
     def is_button_data_proper_type(button_data) -> None:
         if not isinstance(button_data, (tuple, dict, str, int)):
             type_error_message = (
-                "Cannot create %s from %s. Please use %s instead.\n"
+                f"Cannot create {InlineKeyboardButton} from {type(button_data)}. "
+                f"Please use {InlineButtonData} instead.\n"
                 "Probably you specified 'auto_alignment' or 'items_in_line' "
                 "parameter for StructuredSequence."
-                % (InlineKeyboardButton, type(button_data), InlineButtonData)
             )
             raise TypeError(type_error_message)
 
     @staticmethod
     def is_callback_proper_type(callback) -> None:
         if not isinstance(callback, callback_data_types):
-            type_error_message = "Callback cannot be %s. Only %s allowed." % (
-                type(callback),
-                callback_data_types,
+            type_error_message = (
+                f"Callback cannot be {type(callback)}. "
+                f"Only {callback_data_types} allowed."
             )
             raise TypeError(type_error_message)
 
@@ -42,6 +42,6 @@ class ButtonCheck:
         if len(callback_data.encode()) > MAXIMUM_CBD_LENGTH:
             size_error_message = (
                 "The callback data cannot be more than "
-                "64 bytes for one button. Your size is %s" % len(callback_data.encode())
+                f"64 bytes for one button. Your size is {len(callback_data.encode())}"
             )
             raise ValueError(size_error_message)

--- a/keyboa/keyboard.py
+++ b/keyboa/keyboard.py
@@ -160,8 +160,8 @@ class Keyboa(Base):
 
             if not isinstance(keyboard, InlineKeyboardMarkup):
                 type_error_message = (
-                    "Keyboard cannot be %s. Only InlineKeyboardMarkup allowed."
-                    % type(keyboard)
+                    f"Keyboard cannot be {type(keyboard)}. "
+                    "Only InlineKeyboardMarkup allowed."
                 )
                 raise TypeError(type_error_message)
             data.extend(keyboard.keyboard)


### PR DESCRIPTION
- Replace old-style `%` string formatting with f-strings for better readability
- Update type error and value error messages to use f-string interpolation
- Add detailed docstring to `button` property in `keyboa/button.py`
- Minor code cleanup: replace `str()` with `""` for empty string initialization
- Add explicit `None` return type annotation to `__init__` methods
- Enforce keyword-only arguments in `__init__` for better API clarity